### PR TITLE
Fix doc for SocialTokenizer preprocessing

### DIFF
--- a/docs/load-preprocessing.rst
+++ b/docs/load-preprocessing.rst
@@ -510,7 +510,7 @@ from ``malaya.preprocessing.get_normalize()``
 
 .. code:: python
 
-    tokenizer = malaya.preprocessing._SocialTokenizer().tokenize
+    tokenizer = malaya.preprocessing.SocialTokenizer().tokenize
 
 .. code:: python
 


### PR DESCRIPTION
Following doc; will get:
```
AttributeError: module 'malaya.preprocessing' has no attribute '_SocialTokenizer'
```