### PR TITLE
fixing transformer model load for topic modelling

### DIFF
--- a/malaya/transformer.py
+++ b/malaya/transformer.py
@@ -17,9 +17,9 @@ def available_model():
 
 @check_type
 def load(
-    size: int = 'base',
-    model: int = 'xlnet',
-    pool_mode: int = 'last',
+    size: str = 'base',
+    model: str = 'xlnet',
+    pool_mode: str = 'last',
     validate: bool = True,
 ):
 


### PR DESCRIPTION
the former code require integer for loading transformer model, while the actual value is string. just minor bug fixing.