### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 pip3 install setuptools -U
-pip3 install tqdm unidecode numpy scipy python-levenshtein tensorflow pyldavis
-pip3 install sklearn_crfsuite sklearn scikit-learn requests fuzzywuzzy
+pip3 install tqdm unidecode numpy scipy tensorflow pyldavis
+pip3 install sklearn_crfsuite sklearn scikit-learn requests rapidfuzz
 pip3 install pandas toolz
 pip3 install PySastrawi matplotlib seaborn networkx
 python3 setup.py install

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -25,19 +25,19 @@ If you get error about `Microsoft Visual C++` during `pip` to install, you need 
       $ pip install tensorflow
       $ pip install pysastrawi
       $ pip install sklearn_crfsuite
-      $ pip install fuzzywuzzy
+      $ pip install rapidfuzz
       $ pip install requests
       $ pip install tqdm
       $ pip install unidecode
       $ pip install toolz
       $ pip install malaya --no-deps -U
 
-But, if you follow these steps, you cannot use Word-Mover interface and fuzzywuzzy might be slow.
+But, if you follow these steps, you cannot use Word-Mover interface.
 
 Dependencies
 ~~~~~~~~~~~~
 
-Malaya depends on numpy, scipy, sklearn, tensorflow, xgboost, nltk, fuzzywuzzy, tqdm and toolz. Dependencies will install automatically during PIP.
+Malaya depends on numpy, scipy, sklearn, tensorflow, xgboost, nltk, rapidfuzz, tqdm and toolz. Dependencies will install automatically during PIP.
 
 Malaya depends on scikit-learn 0.19.1, any upper versions not recommended, stated by sklearn itself. You can install latest scikit-learn as you want, but it will may cause errors or models inefficiency.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ MOCK_MODULES = [
     'tqdm',
     'tensorflow',
     'toolz',
-    'fuzzywuzzy',
+    'rapidfuzz',
     'unidecode',
     'nltk',
     'nltk.tokenize',

--- a/docs/load-clustering.rst
+++ b/docs/load-clustering.rst
@@ -257,7 +257,7 @@ Generate undirected graph for Entities and topics relationship
        topic_length: int, (default=10)
            size of topic models.
        fuzzy_ratio: int, (default=70)
-           size of ratio for fuzzywuzzy.
+           size of ratio for rapidfuzz.
        stemming: bool, (default=True)
            If True, sastrawi_stemmer will apply.
        max_df: float, (default=0.95)

--- a/example/clustering/README.rst
+++ b/example/clustering/README.rst
@@ -257,7 +257,7 @@ Generate undirected graph for Entities and topics relationship
        topic_length: int, (default=10)
            size of topic models.
        fuzzy_ratio: int, (default=70)
-           size of ratio for fuzzywuzzy.
+           size of ratio for rapidfuzz.
        stemming: bool, (default=True)
            If True, sastrawi_stemmer will apply.
        max_df: float, (default=0.95)

--- a/example/clustering/load-clustering.ipynb
+++ b/example/clustering/load-clustering.ipynb
@@ -330,7 +330,7 @@
     "    topic_length: int, (default=10)\n",
     "        size of topic models.\n",
     "    fuzzy_ratio: int, (default=70)\n",
-    "        size of ratio for fuzzywuzzy.\n",
+    "        size of ratio for rapidfuzz.\n",
     "    stemming: bool, (default=True)\n",
     "        If True, sastrawi_stemmer will apply.\n",
     "    max_df: float, (default=0.95)\n",

--- a/malaya/cluster.py
+++ b/malaya/cluster.py
@@ -704,7 +704,7 @@ def cluster_entity_linking(
     topic_length: int, (default=10)
         size of topic models.
     fuzzy_ratio: int, (default=70)
-        size of ratio for fuzzywuzzy.
+        size of ratio for rapidfuzz.
     stemming: bool, (default=True)
         If True, sastrawi_stemmer will apply.
     max_df: float, (default=0.95)
@@ -757,12 +757,12 @@ def cluster_entity_linking(
         import networkx as nx
         import networkx.drawing.layout as nxlayout
         import pandas as pd
-        from fuzzywuzzy import fuzz
+        from rapidfuzz import fuzz
 
         sns.set()
     except:
         raise Exception(
-            'matplotlib, seaborn, networkx, fuzzywuzzy not installed. Please install it and try again.'
+            'matplotlib, seaborn, networkx, rapidfuzz not installed. Please install it and try again.'
         )
 
     if isinstance(corpus, str):
@@ -816,7 +816,7 @@ def cluster_entity_linking(
         for string in corpus:
             if (
                 topic in string
-                or fuzz.token_set_ratio(topic, string) >= fuzzy_ratio
+                or fuzz.token_set_ratio(topic, string, score_cutoff=fuzzy_ratio)
             ):
                 nested_corpus.append(string)
         topics_corpus.append(' '.join(nested_corpus))


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.